### PR TITLE
Call plpython inline

### DIFF
--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -119,7 +119,7 @@ multicorn_init()
 #if PY_MAJOR_VERSION >= 3
 	static char *plpython_module = "plpython3";
 #else
-	static char *plpython_module = "plpython";
+	static char *plpython_module = "plpython2";
 #endif
 	if (inited == true)
 	{

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -148,16 +148,23 @@ multicorn_init()
 
 
 void
-multicorn_call_plpython(char *python_script)
+multicorn_call_plpython(const char *python_script)
 {
-
+	InlineCodeBlock *codeblock = makeNode(InlineCodeBlock);
 	if (multicorn_plpython_inline_handler == NULL)
 	{
 		ereport(ERROR, (errmsg("%s", "No plpython_inline_handler avaiable"), errhint("%s", "Install plpython")));
 	}
 
+	/* We need a copy of the python script, so it's not
+	 * const. 
+	 */
+	codeblock->source_text = pstrdup(python_script);
+	/* XXXXX FIXME, look this up at init time. */
+	codeblock->langIsTrusted = false;
+	codeblock->langOid = InvalidOid;
 	DirectFunctionCall1(multicorn_plpython_inline_handler,
-			    CStringGetDatum(python_script));
+			    PointerGetDatum(codeblock));
 }
 
 

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -110,14 +110,10 @@ MulticornExecState *initializeExecState(void *internal_plan_state);
 /* Hash table mapping oid to fdw instances */
 HTAB	   *InstancesHash;
 
-
-void
-_PG_init()
+static void
+multicorn_init()
 {
-	HASHCTL		ctl;
-	MemoryContext oldctx = MemoryContextSwitchTo(CacheMemoryContext);
 	bool need_import_plpy = false;
-
 #if PY_MAJOR_VERSION >= 3
 	/* Try to load plpython3 with its own module */
 	PG_TRY();
@@ -135,6 +131,17 @@ _PG_init()
 	Py_Initialize();
 	if (need_import_plpy)
 		PyImport_ImportModule("plpy");
+}
+
+
+void
+_PG_init()
+{
+	HASHCTL		ctl;
+	MemoryContext oldctx = MemoryContextSwitchTo(CacheMemoryContext);
+
+	multicorn_init();
+
 	RegisterXactCallback(multicorn_xact_callback, NULL);
 #if PG_VERSION_NUM >= 90300
 	RegisterSubXactCallback(multicorn_subxact_callback, NULL);

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -213,7 +213,7 @@ PyObject   *datumToPython(Datum node, Oid typeoid, ConversionInfo * cinfo);
 List	*serializeDeparsedSortGroup(List *pathkeys);
 List	*deserializeDeparsedSortGroup(List *items);
 
-void multicorn_call_plpython(char *python_script);
+void multicorn_call_plpython(const char *python_script);
 void multicorn_init(void);
 
 #endif   /* PG_MULTICORN_H */

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -213,6 +213,9 @@ PyObject   *datumToPython(Datum node, Oid typeoid, ConversionInfo * cinfo);
 List	*serializeDeparsedSortGroup(List *pathkeys);
 List	*deserializeDeparsedSortGroup(List *items);
 
+void multicorn_call_plpython(char *python_script);
+void multicorn_init(void);
+
 #endif   /* PG_MULTICORN_H */
 
 char	   *PyUnicode_AsPgString(PyObject *p_unicode);

--- a/src/python.c
+++ b/src/python.c
@@ -574,6 +574,9 @@ getCacheEntry(Oid foreigntableid)
 	TupleDesc	desc = rel->rd_att;
 	bool		needInitialization = false;
 
+	/* Make sure we have been inited. */
+	multicorn_init();
+
 	entry = hash_search(InstancesHash, &foreigntableid, HASH_ENTER,
 						&found);
 


### PR DESCRIPTION
I think this is a less hacky way to initialize plpython and multicorn at the same time.  Basically, it just calls plpython_inline_handler and asks it to eval pass.

To do this, we have to initialize things later than in the past.  

This opens the door to creating a utils.plpy_eval function that will run python inside the plpython context for light weight calls to plpython.  We will also be able to setup a trampline via python to wrap the multicorn entry points for a more heavyweight way to guarantee we have the appropriate context for plpy functions to work.

Comments, suggestions? 