### PR TITLE
setup.cfg: Rename pytest to tool:pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 python_files=test*.py


### PR DESCRIPTION
dh_auto_test --buildsystem=pybuild
I: pybuild base:217: cd /<<PKGBUILDDIR>>/.pybuild/cpython3_3.8_multicorn/build; python3.8 -m pytest
[...]
Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
E: pybuild pybuild:352: test: plugin distutils failed with: exit code=1: cd /<<PKGBUILDDIR>>/.pybuild/cpython3_3.8_multicorn/build; python3.8 -m pytest