### PR TITLE
Support PostgreSQL 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,6 @@ ifeq (${SUPPORTS_IMPORT}, 1)
 endif
 
 REGRESS      = $(patsubst test-$(PYTHON_TEST_VERSION)/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --inputdir=test-$(PYTHON_TEST_VERSION) --load-language=plpgsql
+REGRESS_OPTS = --inputdir=test-$(PYTHON_TEST_VERSION)
 
 $(info Python version is $(python_version))

--- a/src/errors.c
+++ b/src/errors.c
@@ -68,9 +68,17 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
 	{
 		severity = ERROR;
 	}
+#if PG_VERSION_NUM >= 130000
+	if (errstart(severity, TEXTDOMAIN))
+#else
 	if (errstart(severity, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
+#endif
 	{
+#if PG_VERSION_NUM >= 130000
+		if (errstart(severity, TEXTDOMAIN))
+#else
 		if (errstart(severity, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
+#endif
 			errmsg("Error in python: %s", errName);
 		errdetail("%s", errValue);
 		errdetail_log("%s", errTraceback);
@@ -81,5 +89,9 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
 	Py_DECREF(tracebackModule);
 	Py_DECREF(newline);
 	Py_DECREF(pTemp);
-	errfinish(0);
+#if PG_VERSION_NUM >= 130000
+		errfinish(__FILE__, __LINE__, PG_FUNCNAME_MACRO);
+#else
+		errfinish(0);
+#endif
 }

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -27,6 +27,9 @@
 #include "utils/rel.h"
 #include "parser/parsetree.h"
 #include "fmgr.h"
+#if PG_VERSION_NUM >= 130000
+#include "common/hashfn.h" /* oid_hash */
+#endif
 
 
 PG_MODULE_MAGIC;

--- a/src/python.c
+++ b/src/python.c
@@ -524,22 +524,37 @@ compareColumns(List *columns1, List *columns2)
 		{
 			return false;
 		}
+#if PG_VERSION_NUM >= 130000
+		cell1 = lnext(coldef1, cell1);
+		cell2 = lnext(coldef2, cell2);
+#else
 		cell1 = lnext(cell1);
 		cell2 = lnext(cell2);
+#endif
 		/* Compare typoid */
 		if (((Const *) (lfirst(cell1)))->constvalue != ((Const *) lfirst(cell2))->constvalue)
 		{
 			return false;
 		}
+#if PG_VERSION_NUM >= 130000
+		cell1 = lnext(coldef1, cell1);
+		cell2 = lnext(coldef2, cell2);
+#else
 		cell1 = lnext(cell1);
 		cell2 = lnext(cell2);
+#endif
 		/* Compare typmod */
 		if (((Const *) (lfirst(cell1)))->constvalue != ((Const *) lfirst(cell2))->constvalue)
 		{
 			return false;
 		}
+#if PG_VERSION_NUM >= 130000
+		cell1 = lnext(coldef1, cell1);
+		cell2 = lnext(coldef2, cell2);
+#else
 		cell1 = lnext(cell1);
 		cell2 = lnext(cell2);
+#endif
 		/* Compare column options */
 		if (!compareOptions(lfirst(cell1), lfirst(cell2)))
 		{

--- a/src/query.c
+++ b/src/query.c
@@ -837,26 +837,49 @@ deserializeDeparsedSortGroup(List *items)
 		ListCell *lc;
 		MulticornDeparsedSortGroup *key =
 			palloc0(sizeof(MulticornDeparsedSortGroup));
+#if PG_VERSION_NUM >= 130000
+		List *list = lfirst(k);
+#endif
 
 		lc = list_head(lfirst(k));
 		key->attname = (Name) strdup(strVal(lfirst(lc)));
 
+#if PG_VERSION_NUM >= 130000
+		lc = lnext(list, lc);
+#else
 		lc = lnext(lc);
+#endif
 		key->attnum = (int) intVal(lfirst(lc));
 
+#if PG_VERSION_NUM >= 130000
+		lc = lnext(list, lc);
+#else
 		lc = lnext(lc);
+#endif
 		key->reversed = (bool) intVal(lfirst(lc));
 
+#if PG_VERSION_NUM >= 130000
+		lc = lnext(list, lc);
+#else
 		lc = lnext(lc);
+#endif
 		key->nulls_first = (bool) intVal(lfirst(lc));
 
+#if PG_VERSION_NUM >= 130000
+		lc = lnext(list, lc);
+#else
 		lc = lnext(lc);
+#endif
 		if(lfirst(lc) != NULL)
 			key->collate = (Name) strdup(strVal(lfirst(lc)));
 		else
 			key->collate = NULL;
 
+#if PG_VERSION_NUM >= 130000
+		lc = lnext(list, lc);
+#else
 		lc = lnext(lc);
+#endif
 		key->key = (PathKey *) lfirst(lc);
 
 		result = lappend(result, key);

--- a/src/utils.c
+++ b/src/utils.c
@@ -89,7 +89,11 @@ log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs)
 	}
 	hint = PyDict_GetItemString(kwargs, "hint");
 	detail = PyDict_GetItemString(kwargs, "detail");
+#if PG_VERSION_NUM >= 130000
+	if (errstart(severity, TEXTDOMAIN))
+#else
 	if (errstart(severity, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
+#endif
 	{
 		errmsg("%s", message);
 		if (hint != NULL && hint != Py_None)
@@ -104,7 +108,11 @@ log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs)
 		}
 		Py_DECREF(args);
 		Py_DECREF(kwargs);
+#if PG_VERSION_NUM >= 130000
+		errfinish(__FILE__, __LINE__, PG_FUNCNAME_MACRO);
+#else
 		errfinish(0);
+#endif
 	}
 	else
 	{

--- a/test-2.7/expected/write_filesystem.out
+++ b/test-2.7/expected/write_filesystem.out
@@ -3,7 +3,7 @@ CREATE EXTENSION multicorn;
 CREATE server multicorn_srv foreign data wrapper multicorn options (
     wrapper 'multicorn.fsfdw.FilesystemFdw'
 );
-CREATE language plpythonu;
+CREATE EXTENSION plpythonu;
 CREATE TABLE temp_dir (dirname varchar);
 -- Create a table with the filesystem fdw in a temporary directory,
 -- and store the dirname in the temp_dir table.
@@ -598,4 +598,4 @@ DROP EXTENSION multicorn cascade;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to server multicorn_srv
 drop cascades to foreign table testmulticorn
-DROP LANGUAGE plpythonu;
+DROP EXTENSION plpythonu;

--- a/test-2.7/sql/write_filesystem.sql
+++ b/test-2.7/sql/write_filesystem.sql
@@ -6,7 +6,7 @@ CREATE server multicorn_srv foreign data wrapper multicorn options (
 );
 
 
-CREATE language plpythonu;
+CREATE EXTENSION plpythonu;
 CREATE TABLE temp_dir (dirname varchar);
 
 -- Create a table with the filesystem fdw in a temporary directory,
@@ -63,4 +63,4 @@ DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();
 DROP EXTENSION multicorn cascade;
-DROP LANGUAGE plpythonu;
+DROP EXTENSION plpythonu;

--- a/test-3.3/expected/write_filesystem.out
+++ b/test-3.3/expected/write_filesystem.out
@@ -1,6 +1,6 @@
 -- Setup the test
 CREATE EXTENSION multicorn;
-CREATE language plpython3u;
+CREATE EXTENSION plpython3u;
 \i test-common/disable_jit.include
 DO $$
 BEGIN
@@ -606,4 +606,4 @@ DROP EXTENSION multicorn cascade;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to server multicorn_srv
 drop cascades to foreign table testmulticorn
-DROP LANGUAGE plpython3u;
+DROP EXTENSION plpython3u;

--- a/test-3.3/sql/write_filesystem.sql
+++ b/test-3.3/sql/write_filesystem.sql
@@ -1,6 +1,6 @@
 -- Setup the test
 CREATE EXTENSION multicorn;
-CREATE language plpython3u;
+CREATE EXTENSION plpython3u;
 \i test-common/disable_jit.include
 
 CREATE OR REPLACE FUNCTION create_table() RETURNS VOID AS $$
@@ -65,4 +65,4 @@ DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();
 DROP EXTENSION multicorn cascade;
-DROP LANGUAGE plpython3u;
+DROP EXTENSION plpython3u;


### PR DESCRIPTION
This patch adds PG 13 compatibility.

I'm submitting it as work in progress because while it passes all regression tests on Debian unstable/amd64, there's some problems that exhibit only on some architecture/distribution combinations, likely because the lnext() handling isn't correct.

It would be nice if someone could have a look if I screwed something up. Thanks!